### PR TITLE
Add badges for docker hub stars and pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # [WIP] Odoo with all OCA code (OCB + addon repositories)
 
+[![Docker Stars](https://img.shields.io/docker/stars/tecnativa/ocb.svg?style=flat-square)](https://hub.docker.com/r/tecnativa/ocb)
+[![Docker Pulls](https://img.shields.io/docker/pulls/tecnativa/ocb.svg?style=flat-square)](https://hub.docker.com/r/tecnativa/ocb)
+
 ## Usage
 
 First of all, please read help for


### PR DESCRIPTION
This is a common practice in common GitHub repos, both **good-looking and functional**, cause both badges serve as links to the docker hub page as well.

@yajo hope  you like it. :sunglasses: 
